### PR TITLE
current_meeting 모듈 생성 및 불필요한 더미 데이터 제거

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -19,14 +19,7 @@ class App extends Component {
     constructor(props){
         super(props);
 
-        this.state = { //결국엔 스토어에 다 넣어야 할 놈들. 특히, 이걸 해결하고나면 rank가 false냐 true냐에 따라 버튼을 바꿔줘야한다. 단, 그전에 axios를 던져놓은 상태여야함
-            current_meeting: {},
-            info: { //test용도 더미 (지워야함)
-                title: "이번주 🔥금 in 강남",
-                msg1: "매칭오픈 - 3월 4일 월요일 오전 10시",
-                msg2: "결과발표 - 3월 6일 수요일 오후 10시",
-                // cutline: 0,
-            },
+        this.state = {
             user: {
                 nickname: "data_닉네임",
                 company: "data_회사명",
@@ -46,23 +39,11 @@ class App extends Component {
                 img_url: "/images/counterProfile.jpeg",
                 team_detail: "data_상대팀소개문구_동해물과 백두산이 마르고 닳도록 하느님이 보우하사 우리나라 만세 무궁화 삼천리 화려강산 대한사람 대한으로 길이 보전하세",
             },
-            meeting: {
-                title: "이번주 🔥금 in 강남",
-                msg1: "매칭오픈 - 3월 4일 월요일 오전 10시",
-                msg2: "결과발표 - 3월 6일 수요일 오후 10시"
-            },
-            cutline: 0,
         }
     }
 
     componentDidMount () {
-        let self = this;
-        axios.get("/current_meeting")
-        .then(response => {
-            console.log(response.data)
-            self.setState({ current_meeting: response.data })
-        })
-        .catch(err => console.log(err));
+        //로그인여부 들어갈 수도 있는 곳
     }
 
     render() {
@@ -73,13 +54,8 @@ class App extends Component {
                         render={(props) => (
                             <Main
                                 {...props}
-                                current_meeting={this.state.current_meeting}
-                                info={this.state.info}
                                 user={this.state.user}
                                 ex_user={this.state.ex_user}
-                                offPopup={this.props.offPopup}
-                                meeting={this.props.meeting}
-                                cutline={this.state.cutline}
                             />
                         )}
                     />

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -83,7 +83,6 @@ class App extends Component {
                             />
                         )}
                     />
-                    {/*offPopup={this.props.offPopup}*/}
                     <Route path="/profile"
                         render={(props) => (
                             <Profile
@@ -98,16 +97,7 @@ class App extends Component {
                                 user={this.state.user}
                             />
                         )} />
-                    <Route path="/chat"
-                        render={(props) => (
-                            <Chat
-                                {...props}
-                                user={this.state.user}
-                                ex_user={this.state.ex_user}//maybe not necessary
-                            />
-                        )} />
                     <Route path="/init" component={Initpage}/>
-                    <Route path="/sign_up" component={SignUp}/>
                     <Route path="/matching_result"
                         render={(props) => (
                             <Result

--- a/frontend/src/components/Main.js
+++ b/frontend/src/components/Main.js
@@ -20,8 +20,7 @@ class Main extends Component {
     }
 
     componentDidMount(){
-        const { CurrentMeetingActions, current_meeting } = this.props;
-
+        const { CurrentMeetingActions } = this.props;
         CurrentMeetingActions.getCurrentMeeting();
 
         try {
@@ -29,7 +28,7 @@ class Main extends Component {
         } catch (error) {
             console.log(error);
         }
-        // 카카오 로그인 버튼을 생성합니다.
+        // 카카오 로그인 버튼을 생성
         window.Kakao.Auth.createLoginButton({
             container: '#kakao-login-btn',
             success: function(authObj) {
@@ -71,7 +70,7 @@ class Main extends Component {
     }
 
     render() {
-        const {user, JoinActions, CurrentMeetingActions, is_joined_popup_on, is_joined_already, rank, current_meeting } = this.props;
+        const {user, JoinActions, is_joined_popup_on, is_joined_already, rank, current_meeting } = this.props;
         return (
             <div className={"frame"}>
 {/*팝업*/}

--- a/frontend/src/components/Main.js
+++ b/frontend/src/components/Main.js
@@ -19,15 +19,6 @@ class Main extends Component {
 
     constructor(props){
         super(props);
-
-        //여기 넣어놔도 문제없을까.
-        let year = this.props.meeting.get('meeting_date').split("-")
-
-        //아직 쓰지 않지만, 이런 식으로 날짜를 파싱해서 프론트에서 사용해야겠다.
-        this.state = {
-            meeting_month: year[1],
-            meeting_day: year[2],
-        }
     }
 
     componentDidMount(){
@@ -100,23 +91,6 @@ class Main extends Component {
                     <div className={"frame-dark fix z-3"}/>
                 </div>
                 }
-
-
-{/*PC전용 1 */}
-                <div className={"mobile-none frame-half abs-right"}>
-                    <Container>
-                        <Container className={"h100percent"}>
-                            <div className={"font-3 font-grey font-bolder mt-4 ml-3"}>
-                                하트 충전하기
-                            </div>
-                            <Heart user={user}/>
-                            <div className={"font-3 font-grey font-bolder mt-5 ml-3"}>
-                                지난 대화목록
-                            </div>
-                            <Chat user={user} ex_user={ex_user}/>
-                        </Container>
-                    </Container>
-                </div>
 
 {/*PC와 모바일 공통*/}
                 <div className="up-bg flex-center frame-half">
@@ -314,7 +288,7 @@ const mapDispatchToProps = (dispatch) => ({
 const mapStateToProps = (state) => ({
     is_joined_popup_on: state.join.get('is_joined_popup_on'),
     is_joined_already: state.join.get('is_joined_already'),
-    meeting: state.join.get('meeting'),
+    current_meeting: state.current_meeting.get('current_meeting'),
     rank: state.join.get('rank'),
 })
 

--- a/frontend/src/components/Main.js
+++ b/frontend/src/components/Main.js
@@ -12,6 +12,7 @@ import Chat from "./details/Chat";
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import * as actions from '../modules/join';
+import * as actions2 from '../modules/current_meeting';
 import axios from 'axios'; //카카오로그인 실험용
 
 class Main extends Component {
@@ -81,18 +82,18 @@ class Main extends Component {
     // }
 
     render() {
-        const {user, Actions, is_joined, is_joined_done, ex_user, current_meeting, info, rank } = this.props;
+        const {user, Actions, is_joined_popup_on, is_joined_already, ex_user, current_meeting, info, rank } = this.props;
         return (
             <div className={"frame"}>
 {/*팝업*/}
-                {is_joined &&
+                {is_joined_popup_on &&
                 <div className={"App"}>
                     <div className={"flex-center"}>
                         <div className={"fix minus-height z-4"}>
                             <JoinedPopup
                                 rank={rank}
                                 deletePopup={Actions.deletePopup}
-                                is_joined_done={is_joined_done}
+                                is_joined_already={is_joined_already}
                             />
                         </div>
                     </div>
@@ -146,7 +147,7 @@ class Main extends Component {
                             <Col xs={12} className={"flex-center"}>
 
                                 {/*추후 조건부 렌더 필요한부분*/}
-                                {is_joined_done
+                                {is_joined_already
                                     ? (<div className={"big-button-black flex-center font-2 font-white"}
                                             onClick={Actions.reclickJoinedPopup}>
                                         현재 순위: {rank}위
@@ -311,8 +312,8 @@ const mapDispatchToProps = (dispatch) => ({
 });
 
 const mapStateToProps = (state) => ({
-    is_joined: state.join.get('is_joined'),
-    is_joined_done: state.join.get('is_joined_done'),
+    is_joined_popup_on: state.join.get('is_joined_popup_on'),
+    is_joined_already: state.join.get('is_joined_already'),
     meeting: state.join.get('meeting'),
     rank: state.join.get('rank'),
 })

--- a/frontend/src/components/Main.js
+++ b/frontend/src/components/Main.js
@@ -7,12 +7,10 @@ import { Link } from 'react-router-dom';
 import JoinedPopup from "./popups/JoinedPopup";
 import { CopyToClipboard } from 'react-copy-to-clipboard';
 import Footer from "./Footer";
-import Heart from "./details/Heart";
-import Chat from "./details/Chat";
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
-import * as actions from '../modules/join';
-import * as actions2 from '../modules/current_meeting';
+import * as joinActions from '../modules/join';
+import * as currentMeetingActions from '../modules/current_meeting';
 import axios from 'axios'; //카카오로그인 실험용
 
 class Main extends Component {
@@ -22,6 +20,10 @@ class Main extends Component {
     }
 
     componentDidMount(){
+        const { CurrentMeetingActions, current_meeting } = this.props;
+
+        CurrentMeetingActions.getCurrentMeeting();
+
         try {
             window.Kakao.init(process.env.REACT_APP_KAKAO_JAVSCRIPT_SDK_KEY);            
         } catch (error) {
@@ -68,12 +70,8 @@ class Main extends Component {
         .catch(err => console.log(err));
     }
 
-    // join() {
-    //     const { Actions } = this.props;
-    // }
-
     render() {
-        const {user, Actions, is_joined_popup_on, is_joined_already, ex_user, current_meeting, info, rank } = this.props;
+        const {user, JoinActions, CurrentMeetingActions, is_joined_popup_on, is_joined_already, rank, current_meeting } = this.props;
         return (
             <div className={"frame"}>
 {/*팝업*/}
@@ -83,7 +81,7 @@ class Main extends Component {
                         <div className={"fix minus-height z-4"}>
                             <JoinedPopup
                                 rank={rank}
-                                deletePopup={Actions.deletePopup}
+                                deletePopup={JoinActions.deletePopup}
                                 is_joined_already={is_joined_already}
                             />
                         </div>
@@ -94,7 +92,6 @@ class Main extends Component {
 
 {/*PC와 모바일 공통*/}
                 <div className="up-bg flex-center frame-half">
-
                     <div className={"fix flex-center frame-half"}>
                         <img src={user.img_url} className={"bg-under-img"} alt={"profile-large-img"}/>
                     </div>
@@ -103,7 +100,6 @@ class Main extends Component {
                         <Row className={"App"}>
                             <Col xs={12}>
                                 <div className={"font-big font-white mt-4"}>
-                                    {/* {this.props.info.title} */}
                                     {current_meeting.location}
                                     <br/>
                                     <a id="kakao-login-btn"></a>
@@ -112,10 +108,10 @@ class Main extends Component {
                             </Col>
                             <Col xs={12}>
                                 <div className={"font-1 font-white mt-3 opacity05"}>
-                                    {info.msg1}
+                                    {current_meeting.first_shuffle_time}
                                 </div>
                                 <div className={"font-1 font-white mt-1 opacity05"}>
-                                    {info.msg2}
+                                    {current_meeting.second_shuffle_time}
                                 </div>
                             </Col>
                             <Col xs={12} className={"flex-center"}>
@@ -123,11 +119,11 @@ class Main extends Component {
                                 {/*추후 조건부 렌더 필요한부분*/}
                                 {is_joined_already
                                     ? (<div className={"big-button-black flex-center font-2 font-white"}
-                                            onClick={Actions.reclickJoinedPopup}>
+                                            onClick={JoinActions.reclickJoinedPopup}>
                                         현재 순위: {rank}위
                                     </div>)
                                     : (<div className={"big-button-red flex-center font-2 font-white"}
-                                            onClick={Actions.createJoinedPopup}>
+                                            onClick={JoinActions.createJoinedPopup}>
                                         선착순 번호표 뽑기
                                         {/*{this.props.cutline}*/}
                                     </div>)}
@@ -204,9 +200,7 @@ class Main extends Component {
                             </Row>
                         </Container>
                     </div>
-
-{/*PC 전용 2 */}
-
+{/*PC 전용 */}
                     <div className={"profile mobile-none z-2"}>
                         {/*<div className="profile h100percent w50percent bg-white fix z-1"/>*/}
                         <div className={"pc-max-width z-2"}>
@@ -251,11 +245,8 @@ class Main extends Component {
                                     <Col xs={9} className={"align-left"}>
                                         <div className={"font-1 ml-1"}>
                                             <b>
-                {/*for test*/}
-                                                <Link to="/matching_result">
-                                                <span className="font-black deco-none">친구</span>
-                                                </Link> 초대 </b>
-                {/*end here*/}
+                                                <span className="font-black deco-none">친구</span>초대
+                                            </b>
                                             <font color="#808080" size="10px">(추천인코드: <strong>{user.recommendation_code}</strong>)</font>
                                             </div>
                                         <div className={"font-05 ml-1 mt-2"}>여자사람친구를 초대해주세요.</div>
@@ -282,14 +273,15 @@ class Main extends Component {
 
 const mapDispatchToProps = (dispatch) => ({
     dispatch,
-    Actions: bindActionCreators(actions, dispatch),
+    JoinActions: bindActionCreators(joinActions, dispatch),
+    CurrentMeetingActions: bindActionCreators(currentMeetingActions, dispatch),
 });
 
 const mapStateToProps = (state) => ({
     is_joined_popup_on: state.join.get('is_joined_popup_on'),
     is_joined_already: state.join.get('is_joined_already'),
-    current_meeting: state.current_meeting.get('current_meeting'),
     rank: state.join.get('rank'),
+    current_meeting: state.current_meeting.get('current_meeting'),
 })
 
 export default connect(mapStateToProps, mapDispatchToProps)(Main);

--- a/frontend/src/components/popups/JoinedPopup.js
+++ b/frontend/src/components/popups/JoinedPopup.js
@@ -14,7 +14,7 @@ class JoinedPopup extends Component {
                 <div  className={"abs hover"} onClick={this.props.deletePopup}>
                     <MaterialIcon icon="clear" size="25px" color="lightgrey"/>
                 </div>
-                {this.props.is_joined_done
+                {this.props.is_joined_already
                 ?
                 (<div className={"copy-pop flex-center font-1"}>
                     이미 번호표를 뽑으셨어요! 결과발표 전까지 조금만 기다려주세요.

--- a/frontend/src/modules/current_meeting.js
+++ b/frontend/src/modules/current_meeting.js
@@ -6,7 +6,7 @@ import { pender } from 'redux-pender';
 const GET_MEETING_INFO = `GET_MEETING_INFO`;
 
 const initialState = Map({
-    meeting: Map({
+    current_meeting: Map({
         id: 3,
         starting_date: "2019-04-24T10:00:00.000Z",
         mid_date: "2019-05-25T10:00:00.000Z",
@@ -19,8 +19,7 @@ const initialState = Map({
 export default handleActions({
     ...pender({
         type: GET_MEETING_INFO,
-        onSuccess: (state, action) => state.set('rank', action.payload.data.rank)
-                                            .set('is_joined', true),
+        onSuccess: (state, action) => state.set('current_meeting', action.payload.data.meeting)
     }),
 }, initialState);
 

--- a/frontend/src/modules/current_meeting.js
+++ b/frontend/src/modules/current_meeting.js
@@ -3,28 +3,21 @@ import { Map } from 'immutable';
 import axios from 'axios';
 import { pender } from 'redux-pender';
 
-const GET_MEETING_INFO = `GET_MEETING_INFO`;
+const GET_CURRENT_MEETING = `GET_CURRENT_MEETING`;
 
 const initialState = Map({
-    current_meeting: Map({
-        id: 3,
-        starting_date: "2019-04-24T10:00:00.000Z",
-        mid_date: "2019-05-25T10:00:00.000Z",
-        meeting_date: "2019-12-25T22:00:00.000Z",
-        location: "Hongdae",
-        cutline: 0,
-    }),
+    current_meeting: Map({}),
 }); 
 
 export default handleActions({
     ...pender({
-        type: GET_MEETING_INFO,
-        onSuccess: (state, action) => state.set('current_meeting', action.payload.data.meeting)
+        type: GET_CURRENT_MEETING,
+        onSuccess: (state, action) => state.set('current_meeting', action.payload.data)
     }),
 }, initialState);
 
-export const getMeetingInfo = createAction(
-    GET_MEETING_INFO,
+export const getCurrentMeeting = createAction(
+    GET_CURRENT_MEETING,
     (payload) => axios({
         method: 'get',
         url: '/current_meeting',

--- a/frontend/src/modules/current_meeting.js
+++ b/frontend/src/modules/current_meeting.js
@@ -1,0 +1,41 @@
+import { createAction, handleActions } from 'redux-actions';
+import { Map } from 'immutable';
+import axios from 'axios';
+import { pender } from 'redux-pender';
+
+const GET_MEETING_INFO = `GET_MEETING_INFO`;
+
+const initialState = Map({
+    meeting: Map({
+        id: 3,
+        starting_date: "2019-04-24T10:00:00.000Z",
+        mid_date: "2019-05-25T10:00:00.000Z",
+        meeting_date: "2019-12-25T22:00:00.000Z",
+        location: "Hongdae",
+        cutline: 0,
+    }),
+}); 
+
+export default handleActions({
+    ...pender({
+        type: GET_MEETING_INFO,
+        onSuccess: (state, action) => state.set('rank', action.payload.data.rank)
+                                            .set('is_joined', true),
+    }),
+}, initialState);
+
+export const getMeetingInfo = createAction(
+    GET_MEETING_INFO,
+    (payload) => axios({
+        method: 'get',
+        url: '/current_meeting',
+    })
+    .then((response) => {
+        console.log("this is working OOOOO");
+        console.log(response);
+        return response
+    })
+    .catch(
+        console.log("not working XXXXX")
+    )
+);

--- a/frontend/src/modules/index.js
+++ b/frontend/src/modules/index.js
@@ -3,10 +3,12 @@ import { penderReducer } from "redux-pender";
 // import { reducer as formReducer } from "redux-form/immutable";
 // 이건 redux-form을 이용하기 위한 친구인데 일단 보류
 import join from './join';
+import current_meeting from './current_meeting';
 
 export default combineReducers({
     pender: penderReducer,
     // form: formReducer,
     // 이건 redux-form을 이용하기 위한 친구인데 일단 보류
     join,
+    current_meeting,
 });

--- a/frontend/src/modules/join.js
+++ b/frontend/src/modules/join.js
@@ -15,8 +15,8 @@ const GET_MEETING_INFO = `GET_MEETING_INFO`;
 
 
 const initialState = Map({
-    is_joined: false,
-    is_joined_done: false,
+    is_joined_popup_on: false,
+    is_joined_already: false,
     meeting: Map({
         id: 3,
         starting_date: "2019-04-24T10:00:00.000Z",
@@ -29,16 +29,16 @@ const initialState = Map({
 
 export default handleActions({
     [DELETE_POPUP]: (state, action) => {
-        return state.set('is_joined', false)
-                    .set('is_joined_done', true);
+        return state.set('is_joined_popup_on', false)
+                    .set('is_joined_already', true);
     },
     ...pender({
         type: CREATE_JOINED_POPUP,
         onSuccess: (state, action) => state.set('rank', action.payload.data.rank)
-                                            .set('is_joined', true),
+                                            .set('is_joined_popup_on', true),
     }),
     [RECLICK_JOINED_POPUP]: (state, action) => {
-        return state.set('is_joined', true)
+        return state.set('is_joined_popup_on', true)
     },
     [GET_MEETING_INFO]: (state, action) => {
         return


### PR DESCRIPTION
**진행내용**
1. current_meeting.js 모듈 신규 생성 : CurrentMeeting API를 get해서 Store에 담기 위한 모듈이고, componentDidMount에서 액션생성이 이루어지도록 해두었음
2. joinePopup관련하여 is_joined와 is_joined_done의 이름이 비슷해 역할이 헷갈리므로 각각 is_joined_popup_on, is_joined_already로 수정했음.(전자는 팝업을 띄워주기 위한 것, 후자는 이 사용자가 이미 JoinedUser API를 post한 적이 있었는지에 대한 것)
3. 미팅정보 관련하여 기존 코드들이 불필요해졌으므로 제거

**참고**
- 아직 user라든지 ex_user라든지 하는 불필요한 state들이 남아있지만, 이건 연석이와 관련된 부분일 것 같아서 지우진 않았습니다.
@choiyeonseok 추후, Profile API와 CounterProfile API를 get하게 되면 그때 이걸 지우고  store에 있는 State들을 이용해 UI를 구성하면 됩니다.)

**후속계획**
- componentDidMount에서 is_joined_already를 판별할 수 있는 로직 넣을 예정(feature/join 브랜치 재활용)