### PR TITLE
참여 여부에 따라 버튼색 분기 처리

### DIFF
--- a/backend/meeting/views.py
+++ b/backend/meeting/views.py
@@ -175,8 +175,8 @@ class Join(APIView):
 
     def get(self, request, format=None):
         my_profile = request.user.profile
-        if my_profile is not None and self.current_meeting is not None:
-            queryset = JoinedUser.objects.filter(profile=my_profile, meeting=self.current_meeting).first()
+        queryset = JoinedUser.objects.filter(profile=my_profile, meeting=self.current_meeting).last()
+        if queryset is not None:
             serializer = JoinSerializer(queryset)
             return Response(serializer.data, status=status.HTTP_200_OK)
         else:

--- a/frontend/src/components/Main.js
+++ b/frontend/src/components/Main.js
@@ -20,8 +20,9 @@ class Main extends Component {
     }
 
     componentDidMount(){
-        const { CurrentMeetingActions } = this.props;
+        const { CurrentMeetingActions, JoinActions } = this.props;
         CurrentMeetingActions.getCurrentMeeting();
+        JoinActions.getJoinedUser();
 
         try {
             window.Kakao.init(process.env.REACT_APP_KAKAO_JAVSCRIPT_SDK_KEY);            
@@ -70,7 +71,7 @@ class Main extends Component {
     }
 
     render() {
-        const {user, JoinActions, is_joined_popup_on, is_joined_already, rank, current_meeting } = this.props;
+        const {user, JoinActions, is_joined_popup_on, is_joined_already, joined_user, current_meeting } = this.props;
         return (
             <div className={"frame"}>
 {/*팝업*/}
@@ -79,7 +80,7 @@ class Main extends Component {
                     <div className={"flex-center"}>
                         <div className={"fix minus-height z-4"}>
                             <JoinedPopup
-                                rank={rank}
+                                rank={joined_user.rank}
                                 deletePopup={JoinActions.deletePopup}
                                 is_joined_already={is_joined_already}
                             />
@@ -119,7 +120,7 @@ class Main extends Component {
                                 {is_joined_already
                                     ? (<div className={"big-button-black flex-center font-2 font-white"}
                                             onClick={JoinActions.reclickJoinedPopup}>
-                                        현재 순위: {rank}위
+                                        현재 순위: {joined_user.rank}위
                                     </div>)
                                     : (<div className={"big-button-red flex-center font-2 font-white"}
                                             onClick={JoinActions.createJoinedPopup}>
@@ -279,7 +280,7 @@ const mapDispatchToProps = (dispatch) => ({
 const mapStateToProps = (state) => ({
     is_joined_popup_on: state.join.get('is_joined_popup_on'),
     is_joined_already: state.join.get('is_joined_already'),
-    rank: state.join.get('rank'),
+    joined_user: state.join.get('joined_user'),
     current_meeting: state.current_meeting.get('current_meeting'),
 })
 

--- a/frontend/src/modules/join.js
+++ b/frontend/src/modules/join.js
@@ -2,29 +2,15 @@ import { createAction, handleActions } from 'redux-actions';
 import { Map } from 'immutable';
 import axios from 'axios';
 import { pender } from 'redux-pender';
-// import {getMeetingInfo} from '../actions/index'
 
-// const prefix = "join";
 const DELETE_POPUP = `DELETE_POPUP`;
 const CREATE_JOINED_POPUP = `CREATE_JOINED_POPUP`;
 const RECLICK_JOINED_POPUP = `RECLICK_JOINED_POPUP`;
-const GET_MEETING_INFO = `GET_MEETING_INFO`;
-// const DELETE_POPUP = `${prefix}/DELETE_POPUP`;
-// const CREATE_JOINED_POPUP = `${prefix}/CREATE_JOINED_POPUP`;
-// const GET_MEETING_INFO = `${prefix}/GET_MEETING_INFO`;
-
+const GET_JOINED_USER = `GET_JOINED_USER`;
 
 const initialState = Map({
     is_joined_popup_on: false,
     is_joined_already: false,
-    meeting: Map({
-        id: 3,
-        starting_date: "2019-04-24T10:00:00.000Z",
-        mid_date: "2019-05-25T10:00:00.000Z",
-        meeting_date: "2019-12-25T22:00:00.000Z",
-        location: "Hongdae",
-        cutline: 0,
-    }),
 }); 
 
 export default handleActions({
@@ -34,14 +20,17 @@ export default handleActions({
     },
     ...pender({
         type: CREATE_JOINED_POPUP,
-        onSuccess: (state, action) => state.set('rank', action.payload.data.rank)
+        onSuccess: (state, action) => state.set('joined_user', action.payload.data)
                                             .set('is_joined_popup_on', true),
     }),
+    ...pender({
+        type: GET_JOINED_USER,
+        onSuccess: (state, action) => state.set('joined_user', action.payload.data)
+                                            .set('is_joined_already', true),
+        onFailure: (state, action) => state.set('is_joined_already', false),
+    }),
     [RECLICK_JOINED_POPUP]: (state, action) => {
-        return state.set('is_joined_popup_on', true)
-    },
-    [GET_MEETING_INFO]: (state, action) => {
-        return
+        return state.set('is_joined_popup_on', true);
     },
 }, initialState);
 
@@ -61,5 +50,19 @@ export const createJoinedPopup = createAction(
         console.log("not working")
     )
 );
+export const getJoinedUser = createAction(
+    GET_JOINED_USER,
+    (payload) => axios({
+        method: 'get',
+        url: '/join',
+    })
+    .then((response) => {
+        console.log("this is working");
+        console.log(response);
+        return response
+    })
+    .catch(
+        console.log("not working")
+    )
+);
 export const reclickJoinedPopup = createAction(RECLICK_JOINED_POPUP, payload => payload);
-export const getMeetingInfo = createAction(GET_MEETING_INFO, payload => payload);


### PR DESCRIPTION
**[참고사항]**
- pull request가 2개인 상황에서, Reviewers가 file의 diff를 잘 볼 수 있도록 하기 위해서 develop branch 대신 feature/current_meeting branch로 병합하는 걸로 임시설정해두었습니다. current_meeting branch가 develop branch에 merge되고 나면 이 PR도 develop branch로 merge하도록 수정할 예정입니다.

**[진행내용]**
- Join API의 get을 componentDidMount에서 사용하여 is_joined_already가 true인지 false인지 판단했음. 따라서 기존과 다르게, 이미 Join한 사용자는 새로고침을 해도 검정버튼이 남게 되었음

**[의견공유필요]**
- Join API get호출 시 joined_user가 없다면 404 error를 띄워줌으로써 이걸 프론트에서는 onFailure로 인식해 빨간버튼을 띄워주는 걸로 했는데, 이렇게 error갖다가 버튼을 핸들링하는 게 과연 맞는 방법인지?
@qwerty98765 @choiyeonseok 